### PR TITLE
fix: org name typo

### DIFF
--- a/infrastructure/environments/dev/oidc/variables.tf
+++ b/infrastructure/environments/dev/oidc/variables.tf
@@ -30,7 +30,7 @@ variable "prefix" {
 variable "display_name" {
   description = "display name for the federated identity credential"
   type        = string
-  default     = "gha-fic-tfaz"
+  default     = "gha-oidc-tfaz"
 }
 
 variable "gh_org_name" {

--- a/infrastructure/environments/dev/oidc/variables.tf
+++ b/infrastructure/environments/dev/oidc/variables.tf
@@ -36,7 +36,7 @@ variable "display_name" {
 variable "gh_org_name" {
   type        = string
   description = "GitHub organization name."
-  default     = "hemsarz"
+  default     = "HemSarz"
 }
 
 variable "gh_repo_name" {


### PR DESCRIPTION
fix: corrected typo for org name - hemsarz > HemSarz | gha-fic-tfaz > gha-oidc-tfaz