### PR TITLE
backend-infra-dev.yml

### DIFF
--- a/infrastructure/environments/dev/backend.tf
+++ b/infrastructure/environments/dev/backend.tf
@@ -25,6 +25,7 @@ provider "azurerm" {
       recover_soft_deleted_certificates = false
     }
   }
+  use_oidc = true
 }
 
 /*


### PR DESCRIPTION
fix: added uses_oidc to backend.tf to be able to use oidc & use az storage as bcknd